### PR TITLE
demux: Fixed an issue when reading unexistent keys

### DIFF
--- a/demux.go
+++ b/demux.go
@@ -1,6 +1,7 @@
 package mxwriter
 
 import (
+	"bytes"
 	"errors"
 	"io"
 )
@@ -16,7 +17,8 @@ type Demux struct {
 }
 
 // NewDemux returns an new Demux from the w, which has
-// to be a *mux implementation to work
+// to be a *mux implementation to work. Otherwise it'll
+// return a ErrNotMux
 func NewDemux(w interface{}) (*Demux, error) {
 	mux, ok := w.(*mux)
 	if !ok {
@@ -36,10 +38,21 @@ func (d *Demux) Keys() []string {
 }
 
 // Read will return a io.Reader from the specific key
+// and consider it already read so it'll remove it.
+// If the k does not exists it'll return an empty io.Reader
 func (d *Demux) Read(k string) io.Reader {
 	buff, ok := d.mux.buffers[k]
 	if !ok {
-		return nil
+		return &bytes.Buffer{}
+	}
+
+	delete(d.mux.buffers, k)
+
+	for i, kk := range d.mux.keys {
+		if kk == k {
+			d.mux.keys = append(d.mux.keys[:i], d.mux.keys[i+1:]...)
+			break
+		}
 	}
 
 	return buff

--- a/demux.go
+++ b/demux.go
@@ -12,6 +12,7 @@ var ErrNotMux = errors.New("io.ReadWriter it's not of type mux")
 // Demux can be used to Demultiply the *mux
 // by reading specific keys or asking for the
 // list of keys
+// NOTE: Not safe for concurrent use
 type Demux struct {
 	mux *mux
 }

--- a/demux_test.go
+++ b/demux_test.go
@@ -49,20 +49,29 @@ func TestDemuxRead(t *testing.T) {
 		mxwriter.Write(m, "key2", []byte("my-content2"))
 		mxwriter.Write(m, "key1", []byte("my-content"))
 		mxwriter.Write(m, "key3", []byte("my-content3"))
+		mxwriter.Write(m, "key2", []byte("my-content2.1"))
 
 		ior := dm.Read("key1")
 		b, err := ioutil.ReadAll(ior)
 		require.NoError(t, err)
 		assert.Equal(t, []byte("my-content"), b)
+		assert.Equal(t, []string{"key2", "key3"}, dm.Keys())
 
 		ior = dm.Read("key2")
 		b, err = ioutil.ReadAll(ior)
 		require.NoError(t, err)
-		assert.Equal(t, []byte("my-content2"), b)
+		assert.Equal(t, []byte("my-content2my-content2.1"), b)
+		assert.Equal(t, []string{"key3"}, dm.Keys())
 
 		ior = dm.Read("key3")
 		b, err = ioutil.ReadAll(ior)
 		require.NoError(t, err)
 		assert.Equal(t, []byte("my-content3"), b)
+		assert.Equal(t, []string{}, dm.Keys())
+
+		ior = dm.Read("key1")
+		b, err = ioutil.ReadAll(ior)
+		require.NoError(t, err)
+		assert.Equal(t, []byte(""), b)
 	})
 }

--- a/mux.go
+++ b/mux.go
@@ -22,6 +22,7 @@ type mux struct {
 // and later on read them separately by key.
 // To read from an specific key use the NewDemux
 // function to get the Demux
+// NOTE: Not safe for concurrent use
 func NewMux() io.ReadWriter {
 	return &mux{
 		buffers: make(map[string]*bytes.Buffer),


### PR DESCRIPTION
And also made the key be removed once it has been Read, so we can remove it from the Keys list and not listed on the Keys method as an available key.

Also added documentation for it not being concurrent safe.