### PR TITLE
demux: Fixed the Keys fn to not return a reference

### DIFF
--- a/demux.go
+++ b/demux.go
@@ -35,7 +35,11 @@ func NewDemux(w interface{}) (*Demux, error) {
 // the internal mux has and can be read from
 // using the Read
 func (d *Demux) Keys() []string {
-	return d.mux.keys
+	cp := make([]string, len(d.mux.keys))
+	for i, k := range d.mux.keys {
+		cp[i] = k
+	}
+	return cp
 }
 
 // Read will return a io.Reader from the specific key

--- a/demux_test.go
+++ b/demux_test.go
@@ -37,6 +37,22 @@ func TestDemuxKeys(t *testing.T) {
 
 		assert.Equal(t, []string{"key2", "key1", "key3"}, dm.Keys())
 	})
+	t.Run("SuccessWhenReadingKeys", func(t *testing.T) {
+		m := mxwriter.NewMux()
+		dm, err := mxwriter.NewDemux(m)
+		require.NoError(t, err)
+		assert.NotNil(t, dm)
+
+		mxwriter.Write(m, "key2", []byte("my-content2"))
+		mxwriter.Write(m, "key1", []byte("my-content"))
+		mxwriter.Write(m, "key3", []byte("my-content3"))
+
+		keys := []string{"key2", "key1", "key3"}
+		for i, k := range dm.Keys() {
+			assert.Equal(t, keys[i], k)
+			_ = dm.Read(k)
+		}
+	})
 }
 
 func TestDemuxRead(t *testing.T) {


### PR DESCRIPTION
But a copy of the internal keys, as if it was a reference then when using Read it would have removed
the key and as it was a reference then the order would be messed up